### PR TITLE
Add more git conventions

### DIFF
--- a/.github/workflows/git_conventions.yml
+++ b/.github/workflows/git_conventions.yml
@@ -20,3 +20,18 @@ jobs:
               uses: ./src/ensure-linear-history
               with:
                   target-branch: main
+
+    ensure-conventional-commits:
+        name: Ensure Conventional Commits
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  ref: ${{ github.head_ref }}
+
+            - name: Run Check
+              uses: ./src/ensure-conventional-commits
+              with:
+                  target-branch: main

--- a/.github/workflows/git_conventions.yml
+++ b/.github/workflows/git_conventions.yml
@@ -35,3 +35,15 @@ jobs:
               uses: ./src/ensure-conventional-commits
               with:
                   target-branch: main
+
+    ensure-conventional-branches:
+        name: Ensure Conventional Branches
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Run Check
+              uses: ./src/ensure-conventional-branches
+              with:
+                  branch-name: ${{ github.head_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+    pull_request:
+
+jobs:
+    bats:
+        name: Run bats Tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: "24"
+
+            - name: Install bats
+              run: npm install -g bats@1.11.0
+
+            - name: Run tests
+              run: bats --recursive tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,14 @@ and point to the canonical page.
 │   ├── docker.yml              # reusable: build + publish Docker image to ghcr.io
 │   ├── release.yml             # reusable: create GitHub release from CHANGELOG.md
 │   ├── release-ci.yml          # this-repo: cuts the release and updates the major-version tag
-│   ├── git_conventions.yml     # this-repo: linear history check on PRs
+│   ├── git_conventions.yml     # this-repo: linear history, commit, and branch-name checks on PRs
+│   ├── test.yml                # this-repo: runs the bats suite in tests/ on PRs
 │   └── wiki.yml                # this-repo: markdown lint + publish wiki/
+├── tests/                              # bats tests, mirroring src/'s directory structure
+│   ├── test_helper.bash                # shared setup helpers (self-remote git repos, etc.)
+│   ├── ensure-linear-history/          # ensure_linear_history.bats + ensure_same_history.bats
+│   ├── ensure-conventional-commits/    # ensure_conventional_commits.bats
+│   └── ensure-conventional-branches/   # ensure_conventional_branches.bats
 ├── wiki/                       # canonical documentation
 ├── images/                     # logo used in README
 ├── markdownlint.json
@@ -53,21 +59,22 @@ and point to the canonical page.
 
 ## Where to look
 
-| Task                                      | Location                                               | Notes                                                                                   |
-| ----------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| Project overview                          | README.md                                              | High-level pointers.                                                                    |
-| Usage docs for every workflow/action      | wiki/Getting-Started.md                                | Argument tables, YAML examples, defaults.                                               |
-| Contributing reusable workflows / actions | wiki/Contributing.md                                   | Composite action patterns, `${{ github.action_path }}`, release procedure.              |
-| Reusable: build & publish Docker image    | .github/workflows/docker.yml                           | Input: `default-branch` (tagged `latest-dev`). Used by api/frontend/etc.                |
-| Reusable: release with CHANGELOG.md       | .github/workflows/release.yml                          | Inputs: `artifact-name`, `asset-path`, `zip-assets`, `target-branch`.                   |
-| This-repo release                         | .github/workflows/release-ci.yml                       | Cuts releases for this repo; also updates the major-version-only tag (`v1`, ...).       |
-| Action: ensure linear git history         | src/ensure-linear-history/action.yml                   | Checks rebase onto a target branch; no merge commits in history.                        |
-| Action: ensure conventional commits       | src/ensure-conventional-commits/action.yml             | Checks every commit subject against the Conventional Commits spec.                      |
+| Task                                      | Location                                               | Notes                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Project overview                          | README.md                                              | High-level pointers.                                                                               |
+| Usage docs for every workflow/action      | wiki/Getting-Started.md                                | Argument tables, YAML examples, defaults.                                                          |
+| Contributing reusable workflows / actions | wiki/Contributing.md                                   | Composite action patterns, `${{ github.action_path }}`, release procedure.                         |
+| Reusable: build & publish Docker image    | .github/workflows/docker.yml                           | Input: `default-branch` (tagged `latest-dev`). Used by api/frontend/etc.                           |
+| Reusable: release with CHANGELOG.md       | .github/workflows/release.yml                          | Inputs: `artifact-name`, `asset-path`, `zip-assets`, `target-branch`.                              |
+| This-repo release                         | .github/workflows/release-ci.yml                       | Cuts releases for this repo; also updates the major-version-only tag (`v1`, ...).                  |
+| Action: ensure linear git history         | src/ensure-linear-history/action.yml                   | Checks rebase onto a target branch; no merge commits in history.                                   |
+| Action: ensure conventional commits       | src/ensure-conventional-commits/action.yml             | Checks every commit subject against the Conventional Commits spec.                                 |
 | Action: ensure conventional branches      | src/ensure-conventional-branches/action.yml            | Checks branch name against `<type>/<issue-number>-<slug>`; default ignore for releases/dependabot. |
-| Action: markdown lint + link check        | src/lint-md/action.yml                                 | Wraps `markdownlint-cli` + `markup-link-checker`; ignore-paths/links inputs.            |
-| Action: publish wiki/ to GitHub Wiki      | src/wiki-publish/action.yml                            | Expects a `wiki/` dir in the repo; adds an auto-generated hint.                         |
-| Action: upload coverage to Teamscale      | src/teamscale-upload/action.yml                        | Defaults for SnowballR Teamscale; required: `project`, `access-key`, `format`, `files`. |
-| Release procedure (canonical)             | https://github.com/SE-UUlm/snowballr/wiki/Contributing | Single source of truth for SnowballR releases.                                          |
+| Action: markdown lint + link check        | src/lint-md/action.yml                                 | Wraps `markdownlint-cli` + `markup-link-checker`; ignore-paths/links inputs.                       |
+| Action: publish wiki/ to GitHub Wiki      | src/wiki-publish/action.yml                            | Expects a `wiki/` dir in the repo; adds an auto-generated hint.                                    |
+| Action: upload coverage to Teamscale      | src/teamscale-upload/action.yml                        | Defaults for SnowballR Teamscale; required: `project`, `access-key`, `format`, `files`.            |
+| Tests for the shell scripts               | tests/<action-name>/*.bats                             | bats, mirrors src/ layout; git-history tests use a self-remote (`git remote add origin .`).        |
+| Release procedure (canonical)             | https://github.com/SE-UUlm/snowballr/wiki/Contributing | Single source of truth for SnowballR releases.                                                     |
 
 ## Architecture and patterns
 
@@ -99,7 +106,10 @@ and point to the canonical page.
 There is no local build for this repo. Validation happens via:
 
 - The reusable workflows / composite actions themselves running in consumer repos.
-- This repo's own CI (`wiki.yml` for markdown, `git_conventions.yml` for linear history).
+- This repo's own CI (`wiki.yml` for markdown, `git_conventions.yml` for git conventions, `test.yml` for the
+  bats suite in `tests/`).
+- Locally: `bats --recursive tests/` (requires `bats-core`, e.g. `npm install -g bats`) runs the same suite as
+  `test.yml`.
 - Releases: tag `v*.*.*` on `main` to trigger `release-ci.yml`, which runs `release.yml` and updates the
   major-version tag.
 
@@ -115,7 +125,10 @@ There is no local build for this repo. Validation happens via:
 
 - **Style:** Follow `markdownlint.json` for all wiki / README / CHANGELOG content.
 - **Shell scripts:** Keep them POSIX-friendly where possible; place them next to the consuming `action.yml`.
-- **No automated unit tests** for the actions — correctness is validated by consumer repos' CI.
+- **Unit tests:** `src/*/*.sh` scripts that touch git history or plain string checks have `bats` tests under
+  `tests/<action-name>/` (mirroring `src/<action-name>/`, one `*.bats` file per script), with shared repo-setup
+  helpers in `tests/test_helper.bash`; run via `test.yml` on every PR. Scripts that mainly wrap third-party
+  actions (lint-md, wiki-publish, teamscale-upload) are still validated only by consumer repos' CI.
 
 ## Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,13 @@ and point to the canonical page.
 
 ```
 .
-├── src/                        # composite actions (one directory per action)
-│   ├── ensure-linear-history/  # action.yml + shell helpers (ensure_*.sh)
-│   ├── lint-md/                # action.yml + replace-github-urls.js
-│   ├── teamscale-upload/       # action.yml + retrieve_last_commit.sh
-│   └── wiki-publish/           # action.yml + add_auto_gen_wiki_hint.sh
+├── src/                                # composite actions (one directory per action)
+│   ├── ensure-linear-history/          # action.yml + shell helpers (ensure_*.sh)
+│   ├── ensure-conventional-commits/    # action.yml + ensure_conventional_commits.sh
+│   ├── ensure-conventional-branches/   # action.yml + ensure_conventional_branches.sh
+│   ├── lint-md/                        # action.yml + replace-github-urls.js
+│   ├── teamscale-upload/               # action.yml + retrieve_last_commit.sh
+│   └── wiki-publish/                   # action.yml + add_auto_gen_wiki_hint.sh
 ├── .github/workflows/          # reusable workflows + this repo's own CI
 │   ├── docker.yml              # reusable: build + publish Docker image to ghcr.io
 │   ├── release.yml             # reusable: create GitHub release from CHANGELOG.md
@@ -61,6 +63,7 @@ and point to the canonical page.
 | This-repo release                         | .github/workflows/release-ci.yml                       | Cuts releases for this repo; also updates the major-version-only tag (`v1`, ...).       |
 | Action: ensure linear git history         | src/ensure-linear-history/action.yml                   | Checks rebase onto a target branch; no merge commits in history.                        |
 | Action: ensure conventional commits       | src/ensure-conventional-commits/action.yml             | Checks every commit subject against the Conventional Commits spec.                      |
+| Action: ensure conventional branches      | src/ensure-conventional-branches/action.yml            | Checks branch name against `<type>/<issue-number>-<slug>`; default ignore for releases/dependabot. |
 | Action: markdown lint + link check        | src/lint-md/action.yml                                 | Wraps `markdownlint-cli` + `markup-link-checker`; ignore-paths/links inputs.            |
 | Action: publish wiki/ to GitHub Wiki      | src/wiki-publish/action.yml                            | Expects a `wiki/` dir in the repo; adds an auto-generated hint.                         |
 | Action: upload coverage to Teamscale      | src/teamscale-upload/action.yml                        | Defaults for SnowballR Teamscale; required: `project`, `access-key`, `format`, `files`. |
@@ -124,8 +127,10 @@ There is no local build for this repo. Validation happens via:
 
 ## Git and CI conventions
 
-- PRs to `main` must keep a linear git history (`git_conventions.yml`, using this repo's own
-  `src/ensure-linear-history` action — note that it dogfoods its own action).
+- PRs to `main` must keep a linear git history, follow Conventional Commits, and be named
+  `<type>/<issue-number>-<slug>` (`git_conventions.yml`, using this repo's own `src/ensure-linear-history`,
+  `src/ensure-conventional-commits`, and `src/ensure-conventional-branches` actions — note that it dogfoods its
+  own actions).
 - Releases tag `v*.*.*` on `main`; the major-version-only tag is updated automatically (`release-ci.yml`).
 
 ## Conventional commits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ and point to the canonical page.
 | Reusable: release with CHANGELOG.md       | .github/workflows/release.yml                          | Inputs: `artifact-name`, `asset-path`, `zip-assets`, `target-branch`.                   |
 | This-repo release                         | .github/workflows/release-ci.yml                       | Cuts releases for this repo; also updates the major-version-only tag (`v1`, ...).       |
 | Action: ensure linear git history         | src/ensure-linear-history/action.yml                   | Checks rebase onto a target branch; no merge commits in history.                        |
+| Action: ensure conventional commits       | src/ensure-conventional-commits/action.yml             | Checks every commit subject against the Conventional Commits spec.                      |
 | Action: markdown lint + link check        | src/lint-md/action.yml                                 | Wraps `markdownlint-cli` + `markup-link-checker`; ignore-paths/links inputs.            |
 | Action: publish wiki/ to GitHub Wiki      | src/wiki-publish/action.yml                            | Expects a `wiki/` dir in the repo; adds an auto-generated hint.                         |
 | Action: upload coverage to Teamscale      | src/teamscale-upload/action.yml                        | Defaults for SnowballR Teamscale; required: `project`, `access-key`, `format`, `files`. |

--- a/src/ensure-conventional-branches/action.yml
+++ b/src/ensure-conventional-branches/action.yml
@@ -19,4 +19,8 @@ runs:
     steps:
         - name: Ensure branch name follows Conventional Branches
           shell: bash
-          run: bash ${{ github.action_path }}/ensure_conventional_branches.sh -t "${{ inputs.types }}" -i "${{ inputs.ignore-branches }}" "${{ inputs.branch-name }}"
+          env:
+              TYPES: ${{ inputs.types }}
+              IGNORE_BRANCHES: ${{ inputs.ignore-branches }}
+              BRANCH_NAME: ${{ inputs.branch-name }}
+          run: bash ${{ github.action_path }}/ensure_conventional_branches.sh -t "$TYPES" -i "$IGNORE_BRANCHES" "$BRANCH_NAME"

--- a/src/ensure-conventional-branches/action.yml
+++ b/src/ensure-conventional-branches/action.yml
@@ -1,0 +1,22 @@
+name: Ensure Conventional Branches
+description: Ensures that a branch name follows the form <type>/<issue-number>-<slug>
+
+inputs:
+    branch-name:
+        description: The branch name to check.
+        required: true
+    types:
+        description: A comma-separated list of allowed Conventional Commits types.
+        required: false
+        default: "build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test"
+    ignore-branches:
+        description: A comma-separated list of glob patterns; branches matching any of them are skipped.
+        required: false
+        default: "releases/*,dependabot/*"
+
+runs:
+    using: composite
+    steps:
+        - name: Ensure branch name follows Conventional Branches
+          shell: bash
+          run: bash ${{ github.action_path }}/ensure_conventional_branches.sh -t "${{ inputs.types }}" -i "${{ inputs.ignore-branches }}" "${{ inputs.branch-name }}"

--- a/src/ensure-conventional-branches/ensure_conventional_branches.sh
+++ b/src/ensure-conventional-branches/ensure_conventional_branches.sh
@@ -9,6 +9,7 @@ Checks that <branch-name> has the form <type>/<issue-number>-<slug>, where <type
 the allowed Conventional Commits types (https://www.conventionalcommits.org/en/v1.0.0/).
 Example: feat/1-add-login-page
 Defaults: types=build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+          ignore-patterns=releases/*,dependabot/*
 
 Options:
   -t types             Comma-separated list of allowed branch type prefixes
@@ -22,7 +23,7 @@ EOF
 
 # Default values
 types="build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test"
-ignore_patterns=""
+ignore_patterns="releases/*,dependabot/*"
 
 # Parse short options
 while getopts ":t:i:h" opt; do

--- a/src/ensure-conventional-branches/ensure_conventional_branches.sh
+++ b/src/ensure-conventional-branches/ensure_conventional_branches.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage function
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [-t types] [-i ignore-patterns] <branch-name>
+Checks that <branch-name> has the form <type>/<issue-number>-<slug>, where <type> is one of
+the allowed Conventional Commits types (https://www.conventionalcommits.org/en/v1.0.0/).
+Example: feat/1-add-login-page
+Defaults: types=build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+
+Options:
+  -t types             Comma-separated list of allowed branch type prefixes
+  -i ignore-patterns   Comma-separated list of glob patterns; branches matching any of them are skipped
+  -h                   Show this help
+Examples:
+  $(basename "$0") feat/1-add-login-page
+  $(basename "$0") -t "feat,fix" -i "releases/*,dependabot/*" chore/2-bump-deps
+EOF
+}
+
+# Default values
+types="build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test"
+ignore_patterns=""
+
+# Parse short options
+while getopts ":t:i:h" opt; do
+  case $opt in
+  t) types="$OPTARG" ;;
+  i) ignore_patterns="$OPTARG" ;;
+  h)
+    usage
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    usage
+    exit 2
+    ;;
+  :)
+    echo "Option -$OPTARG requires an argument." >&2
+    usage
+    exit 2
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ $# -lt 1 ]; then
+  echo "Missing required <branch-name> argument." >&2
+  usage
+  exit 2
+fi
+branch="$1"
+
+# Skip branches matching any ignore pattern (glob syntax, e.g. "releases/*")
+if [ -n "$ignore_patterns" ]; then
+  IFS=',' read -ra patterns <<<"$ignore_patterns"
+  for pattern in "${patterns[@]}"; do
+    if [[ "$branch" == $pattern ]]; then
+      echo "Branch '$branch' matches ignore pattern '$pattern'; skipping check."
+      exit 0
+    fi
+  done
+fi
+
+# Build a regex matching "<type>/<issue-number>-<slug>", e.g. "feat/1-add-login-page"
+type_pattern=$(echo "$types" | tr ',' '|')
+pattern="^(${type_pattern})/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
+
+if [[ "$branch" =~ $pattern ]]; then
+  echo "Branch '$branch' follows the expected naming convention."
+else
+  echo "::error::Branch '$branch' does not follow the expected naming convention '<type>/<issue-number>-<slug>' (e.g. feat/1-add-login-page)."
+  echo "Allowed types: ${types}"
+  exit 1
+fi

--- a/src/ensure-conventional-commits/action.yml
+++ b/src/ensure-conventional-commits/action.yml
@@ -1,0 +1,22 @@
+name: Ensure Conventional Commits
+description: Ensures that all commits since a target branch follow the Conventional Commits specification
+
+inputs:
+    target-branch:
+        description: The branch that the current branch is based on; commits since this branch are checked.
+        required: true
+    types:
+        description: A comma-separated list of allowed Conventional Commits types.
+        required: false
+        default: "build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test"
+
+runs:
+    using: composite
+    steps:
+        - name: Fetch target branch
+          shell: bash
+          run: git fetch --no-tags --prune origin ${{ inputs.target-branch }}
+
+        - name: Ensure commits follow Conventional Commits
+          shell: bash
+          run: bash ${{ github.action_path }}/ensure_conventional_commits.sh -t "${{ inputs.types }}" ${{ inputs.target-branch }}

--- a/src/ensure-conventional-commits/action.yml
+++ b/src/ensure-conventional-commits/action.yml
@@ -15,8 +15,13 @@ runs:
     steps:
         - name: Fetch target branch
           shell: bash
-          run: git fetch --no-tags --prune origin ${{ inputs.target-branch }}
+          env:
+              TARGET_BRANCH: ${{ inputs.target-branch }}
+          run: git fetch --no-tags --prune origin "$TARGET_BRANCH"
 
         - name: Ensure commits follow Conventional Commits
           shell: bash
-          run: bash ${{ github.action_path }}/ensure_conventional_commits.sh -t "${{ inputs.types }}" ${{ inputs.target-branch }}
+          env:
+              TYPES: ${{ inputs.types }}
+              TARGET_BRANCH: ${{ inputs.target-branch }}
+          run: bash ${{ github.action_path }}/ensure_conventional_commits.sh -t "$TYPES" "$TARGET_BRANCH"

--- a/src/ensure-conventional-commits/ensure_conventional_commits.sh
+++ b/src/ensure-conventional-commits/ensure_conventional_commits.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage function
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [-r remote] [-t types] [branch]
+Checks that all commits reachable from HEAD but not from <remote>/<branch> follow the
+Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/).
+Defaults: remote=origin, branch=develop, types=build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+
+Options:
+  -r remote   Remote name (default: origin)
+  -t types    Comma-separated list of allowed commit types
+  -h          Show this help
+Examples:
+  $(basename "$0")
+  $(basename "$0") feature-branch
+  $(basename "$0") -r origin -t "feat,fix" develop
+EOF
+}
+
+# Default values
+remote="origin"
+branch="develop"
+types="build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test"
+
+# Parse short options
+while getopts ":r:t:h" opt; do
+  case $opt in
+  r) remote="$OPTARG" ;;
+  t) types="$OPTARG" ;;
+  h)
+    usage
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    usage
+    exit 2
+    ;;
+  :)
+    echo "Option -$OPTARG requires an argument." >&2
+    usage
+    exit 2
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+# Positional fallback: if a single positional arg is provided, treat it as branch
+if [ $# -ge 1 ]; then
+  branch="$1"
+  # optionally accept a second positional arg as remote
+  if [ $# -ge 2 ]; then
+    remote="$2"
+  fi
+fi
+
+# Build a regex matching "<type>[(scope)][!]: <description>" as per the
+# Conventional Commits spec (https://www.conventionalcommits.org/en/v1.0.0/)
+type_pattern=$(echo "$types" | tr ',' '|')
+pattern="^(${type_pattern})(\([a-zA-Z0-9/_.-]+\))?!?: .+$"
+
+# Merge commits are excluded: linear history is enforced separately, and merge
+# commit subjects (e.g. "Merge pull request #...") are not meant to follow this spec.
+commits=$(git rev-list --no-merges "${remote}/${branch}"..HEAD)
+if [ -z "$commits" ]; then
+  echo "No commits found since ${remote}/${branch}."
+  exit 0
+fi
+
+invalid_found=0
+for c in $commits; do
+  subject=$(git log -1 --format=%s "$c")
+  if ! [[ "$subject" =~ $pattern ]]; then
+    echo "::error::Commit $c does not follow Conventional Commits: \"$subject\""
+    invalid_found=1
+  fi
+done
+
+if [ "$invalid_found" -eq 1 ]; then
+  echo "One or more commits do not follow the Conventional Commits specification."
+  echo "Allowed types: ${types}"
+  echo "See https://www.conventionalcommits.org/en/v1.0.0/ for details."
+  exit 1
+fi
+
+echo "All commits since ${remote}/${branch} follow the Conventional Commits specification."

--- a/tests/ensure-conventional-branches/ensure_conventional_branches.bats
+++ b/tests/ensure-conventional-branches/ensure_conventional_branches.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../../src/ensure-conventional-branches/ensure_conventional_branches.sh"
+
+@test "When the branch has a valid feat type, then it passes" {
+    run bash "$SCRIPT" "feat/1-branch-name"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"follows the expected naming convention"* ]]
+}
+
+@test "When the branch has a valid fix type, then it passes" {
+    run bash "$SCRIPT" "fix/2-branch-name"
+    [ "$status" -eq 0 ]
+}
+
+@test "When the slug has multiple hyphenated words, then it passes" {
+    run bash "$SCRIPT" "chore/12-bump-deps-a-lot"
+    [ "$status" -eq 0 ]
+}
+
+@test "When the type is not in the allowed list, then it fails" {
+    run bash "$SCRIPT" "feature/1-branch-name"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+}
+
+@test "When the branch has no slash separator, then it fails" {
+    run bash "$SCRIPT" "feat-1-branch-name"
+    [ "$status" -eq 1 ]
+}
+
+@test "When the branch has no issue number, then it fails" {
+    run bash "$SCRIPT" "feat/branch-name"
+    [ "$status" -eq 1 ]
+}
+
+@test "When the branch has no conventional prefix at all, then it fails" {
+    run bash "$SCRIPT" "main"
+    [ "$status" -eq 1 ]
+}
+
+@test "When the branch matches the default releases ignore pattern, then it is skipped" {
+    run bash "$SCRIPT" "releases/v1.1.0"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping check"* ]]
+}
+
+@test "When the branch matches the default dependabot ignore pattern, then it is skipped" {
+    run bash "$SCRIPT" "dependabot/github_actions/actions/checkout-7"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping check"* ]]
+}
+
+@test "When a custom -t types list is given and the type is not included, then it fails" {
+    run bash "$SCRIPT" -t "feat,fix" "chore/3-something"
+    [ "$status" -eq 1 ]
+}
+
+@test "When a custom -i ignore pattern matches the branch, then it is skipped" {
+    run bash "$SCRIPT" -i "wip/*" "wip/anything-goes"
+    [ "$status" -eq 0 ]
+}
+
+@test "When branch-name is missing, then usage is printed and it fails" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "When -h is given, then usage is printed and it exits successfully" {
+    run bash "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/ensure-conventional-commits/ensure_conventional_commits.bats
+++ b/tests/ensure-conventional-commits/ensure_conventional_commits.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load '../test_helper'
+
+SCRIPT="$BATS_TEST_DIRNAME/../../src/ensure-conventional-commits/ensure_conventional_commits.sh"
+
+setup() {
+    setup_repo
+    commit "chore: base"
+    git branch -M main
+    fetch_origin main
+}
+
+@test "When all commits are conventional, then it passes" {
+    git checkout -q -b feature
+    commit "feat(parser): add support for foo"
+    commit "fix: correct off-by-one"
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"follow the Conventional Commits specification"* ]]
+}
+
+@test "When a commit does not follow Conventional Commits, then it fails" {
+    git checkout -q -b feature
+    commit "feat(parser): add support for foo"
+    commit "not a conventional commit"
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" == *"not a conventional commit"* ]]
+}
+
+@test "When a commit has a breaking-change bang, then it passes" {
+    git checkout -q -b feature
+    commit "fix!: breaking change"
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+}
+
+@test "When the only new commit is a merge commit, then it is excluded and passes" {
+    git checkout -q -b other
+    commit "fix: add bar"
+    git checkout -q -b feature main
+    commit "feat: add foo"
+    git merge -q --no-edit other
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+}
+
+@test "When the branch is up to date with the target, then it reports no commits and passes" {
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No commits found"* ]]
+}
+
+@test "When a custom -t types list is given and the type is not included, then it fails" {
+    git checkout -q -b feature
+    commit "chore: bump deps"
+
+    run bash "$SCRIPT" -r origin -t "feat,fix" main
+    [ "$status" -eq 1 ]
+}
+
+@test "When the target branch is given as a positional argument, then it passes" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+
+    run bash "$SCRIPT" main
+    [ "$status" -eq 0 ]
+}

--- a/tests/ensure-linear-history/ensure_linear_history.bats
+++ b/tests/ensure-linear-history/ensure_linear_history.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+load '../test_helper'
+
+SCRIPT="$BATS_TEST_DIRNAME/../../src/ensure-linear-history/ensure_linear_history.sh"
+
+setup() {
+    setup_repo
+    commit "chore: base"
+    git branch -M main
+    fetch_origin main
+}
+
+@test "When there are no merge commits since the target, then it passes" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+    commit "fix: add bar"
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No merge commits found"* ]]
+}
+
+@test "When the current branch equals the target, then it passes" {
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+}
+
+@test "When the target branch was merged into the current branch, then it fails" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+    git checkout -q main
+    commit "chore: unrelated change on main"
+    fetch_origin main
+    git checkout -q feature
+    git merge -q --no-edit main
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" == *"merged"* ]]
+}
+
+@test "When any merge commit exists since the target, even of an unrelated sibling branch, then it fails" {
+    # Both branches fork from the same target tip, so the merge's first parent
+    # still contains the target as an ancestor - the check has no notion of a
+    # "safe" merge, it flags any merge commit found since the target.
+    git checkout -q -b other
+    commit "fix: add bar"
+    git checkout -q -b feature main
+    commit "feat: add foo"
+    git merge -q --no-edit other
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+}
+
+@test "When the branch is given as a positional argument, then it passes" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+
+    run bash "$SCRIPT" main
+    [ "$status" -eq 0 ]
+}
+
+@test "When -h is given, then usage is printed and it exits successfully" {
+    run bash "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/ensure-linear-history/ensure_same_history.bats
+++ b/tests/ensure-linear-history/ensure_same_history.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load '../test_helper'
+
+SCRIPT="$BATS_TEST_DIRNAME/../../src/ensure-linear-history/ensure_same_history.sh"
+
+setup() {
+    setup_repo
+    commit "chore: base"
+    git branch -M main
+    fetch_origin main
+}
+
+@test "When the current branch is rebased onto the target, then it passes" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"has the same history"* ]]
+}
+
+@test "When the current branch has diverged from the target, then it fails" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+    # Advance main independently so the feature branch no longer contains its new tip
+    git checkout -q main
+    commit "chore: unrelated change on main"
+    fetch_origin main
+    git checkout -q feature
+
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" == *"rebase"* ]]
+}
+
+@test "When the current branch equals the target, then it passes" {
+    run bash "$SCRIPT" -r origin main
+    [ "$status" -eq 0 ]
+}
+
+@test "When the branch is given as a positional argument, then it passes" {
+    git checkout -q -b feature
+    commit "feat: add foo"
+
+    run bash "$SCRIPT" main
+    [ "$status" -eq 0 ]
+}
+
+@test "When -h is given, then usage is printed and it exits successfully" {
+    run bash "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,27 @@
+# Shared setup for tests that exercise scripts against a real git history.
+#
+# Scripts under test resolve a target branch via "<remote>/<branch>" (e.g. origin/main).
+# To exercise that without a real network remote, each test repo adds itself as its own
+# "origin" (a local path remote) and fetches from it, exactly as a CI checkout would.
+
+# Creates an empty git repo in a fresh per-test tmp dir and cds into it.
+setup_repo() {
+    repo="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$repo"
+    cd "$repo" || return 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+    git remote add origin .
+}
+
+# Fetches the given branch from the self-remote "origin" so "origin/<branch>" resolves.
+fetch_origin() {
+    git fetch -q origin "$1"
+}
+
+# Creates an empty commit with the given message.
+commit() {
+    git commit -q --allow-empty -m "$1"
+}

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -49,6 +49,27 @@ runs:
 you to easily reference local files within the action. Otherwise, the script would not be found when the action is
 executed.
 
+### Testing local scripts
+
+If a composite action's local script operates on a git repository (checking history, branch names, commit
+messages, ...) or does other logic worth covering directly, add a [bats](https://bats-core.readthedocs.io/) test
+file for it under `tests/<action-name>/`, mirroring the action's directory name under `src/` (e.g. a script in
+`src/example-action/` gets a test file at `tests/example-action/example_script.bats`), run automatically on every
+PR by [`test.yml`](https://github.com/SE-UUlm/snowballr-ci/blob/main/.github/workflows/test.yml). Name each test
+using the "When \<condition\>, then \<expected result\>" pattern, e.g. `@test "When the branch has no issue
+number, then it fails"`. Scripts that need a real git history can add themselves as their own remote instead of
+relying on a real network remote or a throw-away GitHub repository:
+
+```bash
+git init -q
+git remote add origin .
+git fetch -q origin main
+```
+
+See `tests/test_helper.bash` for shared setup helpers (load it with `load '../test_helper'`), and the existing
+`tests/<action-name>/*.bats` files for examples. Run the suite locally with `bats --recursive tests/` (requires
+`bats-core`, e.g. `npm install -g bats`).
+
 ## Release procedure
 
 We create a new release whenever a set of features, bug fixes, or changes is ready to be deployed.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -106,6 +106,8 @@ The following actions are available in this repository:
 - [Ensure Linear Git History](#ensure-linear-git-history): Ensures that the git history of a branch is linear.
 - [Ensure Conventional Commits](#ensure-conventional-commits): Ensures that all commits since a target branch follow
   the Conventional Commits specification.
+- [Ensure Conventional Branches](#ensure-conventional-branches): Ensures that a branch name follows the form
+  `<type>/<issue-number>-<slug>`.
 - [Markdown Lint](#markdown-lint): Lints Markdown files for style and formatting issues.
 - [Wiki Publish](#wiki-publish): Publishes the wiki directory to the GitHub Wiki.
 - [Teamscale Upload](#teamscale-upload): Uploads code coverage reports to Teamscale.
@@ -171,6 +173,36 @@ Arguments:
 | --------------- | -------------------------------------------------------------------------------------- | :------: | :------------------------------------------------------------: |
 | `target-branch` | The branch that the current branch is based on; commits since this branch are checked. |   Yes    |                               -                                |
 | `types`         | A comma-separated list of allowed Conventional Commits types.                          |    No    | `build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test` |
+
+### Ensure Conventional Branches
+
+This action checks that a branch name follows the form `<type>/<issue-number>-<slug>`, e.g. `feat/1-add-login-page`,
+where `<type>` is one of the allowed Conventional Commits types. Branches matching an `ignore-branches` glob pattern
+(e.g., release or Dependabot branches) are skipped.
+
+Usage:
+
+```yaml
+ensure-conventional-branches:
+    name: Ensure Conventional Branches
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v7
+
+        - name: Run Check
+          uses: SE-UUlm/snowballr-ci/src/ensure-conventional-branches@v1
+          with:
+              branch-name: ${{ github.head_ref }}
+```
+
+Arguments:
+
+| Argument          | Description                                                                         | Required |                            Default                             |
+| ----------------- | ----------------------------------------------------------------------------------- | :------: | :------------------------------------------------------------: |
+| `branch-name`     | The branch name to check.                                                           |   Yes    |                               -                                |
+| `types`           | A comma-separated list of allowed Conventional Commits types.                       |    No    | `build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test` |
+| `ignore-branches` | A comma-separated list of glob patterns; branches matching any of them are skipped. |    No    |                   `releases/*,dependabot/*`                    |
 
 ### Markdown Lint
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -104,6 +104,8 @@ Otherwise, no merge is performed.
 The following actions are available in this repository:
 
 - [Ensure Linear Git History](#ensure-linear-git-history): Ensures that the git history of a branch is linear.
+- [Ensure Conventional Commits](#ensure-conventional-commits): Ensures that all commits since a target branch follow
+  the Conventional Commits specification.
 - [Markdown Lint](#markdown-lint): Lints Markdown files for style and formatting issues.
 - [Wiki Publish](#wiki-publish): Publishes the wiki directory to the GitHub Wiki.
 - [Teamscale Upload](#teamscale-upload): Uploads code coverage reports to Teamscale.
@@ -121,7 +123,7 @@ ensure-linear-history:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
           with:
               fetch-depth: 0
               ref: ${{ github.head_ref }}
@@ -138,6 +140,38 @@ Arguments:
 | --------------- | ----------------------------------------------------------- | :------: | :-----: |
 | `target-branch` | The branch onto which the current branch should be rebased. |   Yes    |    -    |
 
+### Ensure Conventional Commits
+
+This action checks that every commit reachable from the current branch but not from a target branch follows the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification, i.e., each commit subject has
+the form `<type>[(scope)][!]: <description>`. Merge commits are excluded from the check.
+
+Usage:
+
+```yaml
+ensure-conventional-commits:
+    name: Ensure Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v7
+          with:
+              fetch-depth: 0
+              ref: ${{ github.head_ref }}
+
+        - name: Run Check
+          uses: SE-UUlm/snowballr-ci/src/ensure-conventional-commits@v1
+          with:
+              target-branch: develop
+```
+
+Arguments:
+
+| Argument        | Description                                                                            | Required |                            Default                             |
+| --------------- | -------------------------------------------------------------------------------------- | :------: | :------------------------------------------------------------: |
+| `target-branch` | The branch that the current branch is based on; commits since this branch are checked. |   Yes    |                               -                                |
+| `types`         | A comma-separated list of allowed Conventional Commits types.                          |    No    | `build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test` |
+
 ### Markdown Lint
 
 This action lints the Markdown files in the wiki and other files, e.g., the README.md and CHANGELOG.md for style and
@@ -151,7 +185,7 @@ lint-md:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Lint Markdown
           uses: SE-UUlm/snowballr-ci/src/lint-md@v1
@@ -197,7 +231,7 @@ publish-wiki:
         contents: write # Required to push to the wiki repository
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Publish Wiki
           uses: SE-UUlm/snowballr-ci/src/wiki-publish@v1
@@ -227,7 +261,7 @@ teamscale-upload:
     needs: coverage-report
     steps:
         - name: Checkout repository
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Download coverage report
           uses: actions/download-artifact@v6


### PR DESCRIPTION
Closes #25

## What I have made

- added `ensure_conventional_commits` action
- added `ensure_conventional_branches` action
- added tests for git conventions actions

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly
- [x] I have manually tested my changes

### Reviewer

- [ ] I have checked the changes against the requirements
